### PR TITLE
FE: Add timeout to full page tests

### DIFF
--- a/koekalenteri-frontend/src/App.test.tsx
+++ b/koekalenteri-frontend/src/App.test.tsx
@@ -6,6 +6,8 @@ import theme from './assets/Theme';
 import { ADMIN_EVENT_TYPES, ADMIN_JUDGES, ADMIN_NEW_EVENT, ADMIN_ORGS, ADMIN_ROOT, ADMIN_USERS, ADMIN_VIEW_EVENT } from './config';
 import { DataGridProps } from '@mui/x-data-grid';
 
+const TIMEOUT = 5000;
+
 jest.mock('./api/event');
 jest.mock('./api/judge');
 jest.mock('./api/official');
@@ -30,12 +32,6 @@ jest.mock('@mui/x-data-grid', () => {
   };
 });
 
-test('renders logo with proper ALT', () => {
-  render(<ThemeProvider theme={theme}><App /></ThemeProvider>, {wrapper: MemoryRouter});
-  const imgElement = screen.getByAltText('Suomen noutajakoirajärjestö');
-  expect(imgElement).toBeInTheDocument();
-});
-
 function renderPath(path: string) {
   render(
     <MemoryRouter initialEntries={[path]}>
@@ -46,25 +42,31 @@ function renderPath(path: string) {
   );
 }
 
-test('renders event page', async () => {
+it('renders logo with proper ALT', () => {
+  renderPath('/');
+  const imgElement = screen.getByAltText('Suomen noutajakoirajärjestö');
+  expect(imgElement).toBeInTheDocument();
+}, TIMEOUT);
+
+it('renders event page', async () => {
   renderPath('/event/NOME-B/test2');
   const spinner = screen.getByRole('progressbar');
   expect(spinner).toBeInTheDocument();
   const organizer = await screen.findByText(/Test org/);
   expect(organizer).toBeInTheDocument();
   expect(spinner).not.toBeInTheDocument();
-});
+}, TIMEOUT);
 
-test('renders event page with date selected', async () => {
+it('renders event page with date selected', async () => {
   renderPath('/event/NOME-B/test2/13.02.');
   const spinner = screen.getByRole('progressbar');
   expect(spinner).toBeInTheDocument();
   const organizer = await screen.findByText(/Test org/);
   expect(organizer).toBeInTheDocument();
   expect(spinner).not.toBeInTheDocument();
-});
+}, TIMEOUT);
 
-test('renders admin default (event) page', async () => {
+it('renders admin default (event) page', async () => {
   renderPath(ADMIN_ROOT);
   const head = await screen.findAllByText(/Tapahtumat/);
   expect(head.length).toBe(2);
@@ -77,15 +79,15 @@ test('renders admin default (event) page', async () => {
   fireEvent.click(screen.getByText(/Muokkaa/));
   const newHead = await screen.findByText(/Muokkaa tapahtumaa/);
   expect(newHead).toBeInstanceOf(HTMLDivElement);
-});
+}, TIMEOUT);
 
-test('renders admin createEvent page', async () => {
+it('renders admin createEvent page', async () => {
   renderPath(ADMIN_NEW_EVENT);
   const head = await screen.findByText(/Uusi tapahtuma/);
   expect(head).toBeInTheDocument();
-});
+}, TIMEOUT);
 
-test('renders admin EventViewPage', async () => {
+it('renders admin EventViewPage', async () => {
   renderPath(`${ADMIN_VIEW_EVENT}/test1`);
   const spinner = screen.getByRole('progressbar');
   expect(spinner).toBeInTheDocument();
@@ -93,31 +95,31 @@ test('renders admin EventViewPage', async () => {
   expect(head).toBeInTheDocument();
 })
 
-test('renders admin organizations', async () => {
+it('renders admin organizations', async () => {
   renderPath(ADMIN_ORGS);
   const head = await screen.findAllByText(/Yhdistykset/);
   expect(head.length).toBe(3);
-});
+}, TIMEOUT);
 
-test('renders admin users', async () => {
+it('renders admin users', async () => {
   renderPath(ADMIN_USERS);
   const head = await screen.findAllByText(/Käyttäjät/);
   expect(head.length).toBe(2);
-});
+}, TIMEOUT);
 
-test('renders admin judges', async () => {
+it('renders admin judges', async () => {
   renderPath(ADMIN_JUDGES);
   const head = await screen.findAllByText(/Tuomarit/);
   expect(head.length).toBe(3);
-});
+}, TIMEOUT);
 
-test('renders admin eventTypes', async () => {
+it('renders admin eventTypes', async () => {
   renderPath(ADMIN_EVENT_TYPES);
   const head = await screen.findAllByText(/Koemuodot/);
   expect(head.length).toBe(3);
-});
+}, TIMEOUT);
 
-test('renders logout page', async () => {
+it('renders logout page', async () => {
   renderPath('/logout');
   expect(await screen.findByText('Kirjaudu')).toBeInTheDocument();
-});
+}, TIMEOUT);


### PR DESCRIPTION
It something starts updating recursively, this makes tests fail in timely manner for local development.