### PR TITLE
Bugfix/koe 334

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ npm run docker-init
 #### Start the dynamodb instance (once, it is persistent)
 
 ```bash
+npm run docker-init
 npm run dynamodb
 ```
 

--- a/koekalenteri-backend/__test__/environment/local/create_tables.sh
+++ b/koekalenteri-backend/__test__/environment/local/create_tables.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/sh
 export JSON_PATH='__test__/environment/local/'
 cd ${JSON_PATH}
 

--- a/koekalenteri-frontend/src/stores/OrganizerStore.ts
+++ b/koekalenteri-frontend/src/stores/OrganizerStore.ts
@@ -26,6 +26,8 @@ export class OrganizerStore {
     const data = await getOrganizers(refresh, signal);
     runInAction(() => {
       data.forEach(json => this.updateOrganizer(json))
+      // Keep the organizers sorted in the store to sort only when the data changes.
+      this.organizers.sort((a,b) => a.name.localeCompare(b.name))
       this.loading = false;
     });
   }


### PR DESCRIPTION
* Keep the organizers sorted in the store. This way the sorting only needs to be done when the data changes and there is no need to cache the sorted data separately to reduce unnecessary renders.
* Also includes minor updates to toplevel readme and create_tables.sh