### PR TITLE
KOE-334

### DIFF
--- a/koekalenteri-frontend/src/stores/OfficialStore.ts
+++ b/koekalenteri-frontend/src/stores/OfficialStore.ts
@@ -1,3 +1,4 @@
+import i18next from "i18next";
 import { Official } from "koekalenteri-shared/model";
 import { makeAutoObservable, runInAction } from "mobx";
 import { getOfficials } from "../api/official";
@@ -27,7 +28,7 @@ export class OfficialStore {
     runInAction(() => {
       this.officials = [];
       data.forEach(json => this.updateOfficial(json));
-      this.officials.sort((a, b) => a.name.localeCompare(b.name))
+      this.officials.sort((a, b) => a.name.localeCompare(b.name, i18next.language))
       this.loading = false;
     });
   }

--- a/koekalenteri-frontend/src/stores/OrganizerStore.ts
+++ b/koekalenteri-frontend/src/stores/OrganizerStore.ts
@@ -1,3 +1,4 @@
+import i18next from "i18next";
 import { Organizer } from "koekalenteri-shared/model";
 import { makeAutoObservable, runInAction } from "mobx";
 import { getOrganizers } from "../api/organizer";
@@ -27,7 +28,7 @@ export class OrganizerStore {
     runInAction(() => {
       data.forEach(json => this.updateOrganizer(json))
       // Keep the organizers sorted in the store to sort only when the data changes.
-      this.organizers.sort((a,b) => a.name.localeCompare(b.name))
+      this.organizers.sort((a,b) => a.name.localeCompare(b.name, i18next.language))
       this.loading = false;
     });
   }


### PR DESCRIPTION
- Fix: force sort locale based on the selected site language when sorting organizers
- Also apply the same of officials sorting