### PR TITLE
feat: friendly name for secretary in email (KOE-350)

### DIFF
--- a/koekalenteri-backend/__test__/unit/utils/strings.test.ts
+++ b/koekalenteri-backend/__test__/unit/utils/strings.test.ts
@@ -1,0 +1,15 @@
+import {capitalize, reverseName} from '../../../src/utils/string';
+
+test('capitalize', function() {
+  expect(capitalize('')).toEqual('')
+  expect(capitalize('matti meikäläinen')).toEqual('Matti Meikäläinen')
+  expect(capitalize('äijä örvelö')).toEqual('Äijä Örvelö')
+  expect(capitalize('elli-noora alexandra kamilla jurvanen')).toEqual('Elli-Noora Alexandra Kamilla Jurvanen')
+});
+
+test('reverseName', function(){
+  expect(reverseName('')).toEqual('')
+  expect(reverseName('Meikäläinen Matti')).toEqual('Matti Meikäläinen')
+  expect(reverseName('Puna-Kuono Petteri')).toEqual('Petteri Puna-Kuono')
+  expect(reverseName('Jurvanen Elli-Noora Alexandra Kamilla')).toEqual('Elli-Noora Jurvanen')
+});

--- a/koekalenteri-backend/package.json
+++ b/koekalenteri-backend/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "main": "index.js",
     "scripts": {
-        "test": "jest",
+        "test": "jest --silent",
         "prebuild": "node copy_i18n.mjs",
         "build": "tsc",
         "prewatch": "node copy_i18n.mjs",

--- a/koekalenteri-backend/src/handlers/event.ts
+++ b/koekalenteri-backend/src/handlers/event.ts
@@ -10,6 +10,7 @@ import { formatDateSpan } from "../utils/dates";
 import { authorize, genericReadAllHandler, genericReadHandler, getOrigin, getUsername } from "../utils/genericHandlers";
 import { metricsError, metricsSuccess } from "../utils/metrics";
 import { response } from "../utils/response";
+import { reverseName } from "../utils/string";
 import { sendTemplatedMail } from "./email";
 
 const dynamoDB = new CustomDynamoClient();
@@ -158,6 +159,11 @@ export const putRegistrationHandler = metricScope((metrics: MetricsLogger) =>
         const from = "koekalenteri@koekalenteri.snj.fi";
         const qualifyingResults = registration.qualifyingResults.map(r => ({ ...r, date: lightFormat(parseISO(r.date), 'd.M.yyyy') }));
         const context = getEmailContext(update, cancel);
+        
+        // Friendly name for secretary (and official) (KOE-350)
+        confirmedEvent.secretary.name = reverseName(confirmedEvent.secretary.name);
+        confirmedEvent.official.name = reverseName(confirmedEvent.official.name);
+
         await sendTemplatedMail('RegistrationV2', registration.language, from, to, {
           subject: t('registration.email.subject', { context }),
           title: t('registration.email.title', { context }),

--- a/koekalenteri-backend/src/utils/string.ts
+++ b/koekalenteri-backend/src/utils/string.ts
@@ -2,3 +2,8 @@
 export function capitalize(s: string) {
   return s.toLowerCase().replace(/(^|[ -])[^ -]/g, (l: string) => l.toUpperCase());
 }
+
+export function reverseName(name: string) {
+  const [last = '', first = ''] = name.split(' ');
+  return `${first} ${last}`.trim()
+}


### PR DESCRIPTION
Rajapinnasta nimet tulee "sukunimi etunime(t)" järjestyksessä yhdessä kentässä. Naiivisti otetaan kaksi ensimmäistä välilyönnillä eroteltua ja käytetään niitä käänteisessä järjestyksessä.

Tätä saa varmasti säätää johonkin suuntaan, kun tehdään muita viestejä (tallentaa johonkin kenties).