### PR TITLE
fix: limit deletion of event to draft/tentative/cancelled

### DIFF
--- a/src/lambda/PutEventFunction/handler.ts
+++ b/src/lambda/PutEventFunction/handler.ts
@@ -2,6 +2,7 @@ import type { JsonConfirmedEvent, JsonUser } from '../../types'
 
 import { nanoid } from 'nanoid'
 
+import { isEventDeletable } from '../../lib/event'
 import { isValidForEntry } from '../../lib/utils'
 import { authorize } from '../lib/auth'
 import { findQualificationStartDate, getEvent, saveEvent, updateRegistrations } from '../lib/event'
@@ -33,6 +34,11 @@ const putEventLambda = lambda('putEvent', async (event) => {
   const existing = item.id ? await getEvent<JsonConfirmedEvent>(item.id) : undefined
 
   if (isUserForbidden(user, existing, item)) {
+    return response(403, 'Forbidden', event)
+  }
+
+  if (item.deletedAt && !isEventDeletable(existing)) {
+    console.log('Event is not deletable', { existing, item })
     return response(403, 'Forbidden', event)
   }
 

--- a/src/lambda/PutEventFunction/putEventLambda.test.ts
+++ b/src/lambda/PutEventFunction/putEventLambda.test.ts
@@ -126,6 +126,28 @@ describe('putEventLambda', () => {
     expect(res2.statusCode).toEqual(403)
   })
 
+  it('should return 403 when trying to delete non-deletable event', async () => {
+    authorizeMock.mockResolvedValueOnce(mockSecretary)
+    getEventMock.mockResolvedValueOnce({ ...mockEvent, state: 'invited' })
+
+    const res = await putEventLambda(
+      constructAPIGwEvent<Partial<JsonDogEvent>>({ id: 'existing', deletedAt: new Date().toISOString() })
+    )
+
+    expect(res.statusCode).toEqual(403)
+  })
+
+  it('should allow deleting a draft event', async () => {
+    authorizeMock.mockResolvedValueOnce(mockSecretary)
+    getEventMock.mockResolvedValueOnce({ ...mockEvent, state: 'draft' })
+
+    const res = await putEventLambda(
+      constructAPIGwEvent<Partial<JsonDogEvent>>({ id: 'existing', deletedAt: new Date().toISOString() })
+    )
+
+    expect(res.statusCode).toEqual(200)
+  })
+
   it('should allow admin to edit any organizers events', async () => {
     authorizeMock.mockResolvedValueOnce(mockAdmin)
     getEventMock.mockResolvedValueOnce({ ...mockEvent, organizer: { id: 'no-access', name: 'some org' } })

--- a/src/lib/event.test.ts
+++ b/src/lib/event.test.ts
@@ -11,6 +11,7 @@ import {
   getEventClassesByDays,
   getEventDays,
   getUniqueEventClasses,
+  isEventDeletable,
   isStartListAvailable,
   newEventEntryEndDate,
   newEventEntryStartDate,
@@ -40,6 +41,21 @@ describe('lib/event', () => {
         expect(isStartListAvailable({ state })).toEqual(false)
       }
     )
+  })
+
+  describe('isEventDeletable', () => {
+    it.each<EventState>(['draft', 'tentative', 'cancelled'])('Should return true when event state is %p', (state) => {
+      expect(isEventDeletable({ state })).toEqual(true)
+    })
+    it.each<EventState>(['completed', 'confirmed', 'ended', 'invited', 'picked', 'started'])(
+      'Should return false when event state is %p',
+      (state) => {
+        expect(isEventDeletable({ state })).toEqual(false)
+      }
+    )
+    it('should return false when event is undefined', () => {
+      expect(isEventDeletable()).toEqual(false)
+    })
   })
 
   describe('eventDays', () => {

--- a/src/lib/event.ts
+++ b/src/lib/event.ts
@@ -33,6 +33,9 @@ export const isStartListAvailable = ({
   (state === 'invited' || state === 'started' || state === 'ended' || state === 'completed') &&
   startListPublished !== false
 
+export const isEventDeletable = ({ state }: Partial<Pick<JsonDogEvent, 'state'>> | undefined = {}) =>
+  state === 'draft' || state === 'tentative' || state === 'cancelled'
+
 export const isDetaultEntryStartDate = (date: Date | undefined, eventStartDate: Date) =>
   !date || isSameDay(defaultEntryStartDate(eventStartDate), date)
 export const isDetaultEntryEndDate = (date: Date | undefined, eventStartDate: Date) =>

--- a/src/pages/admin/EventListPage.tsx
+++ b/src/pages/admin/EventListPage.tsx
@@ -16,6 +16,7 @@ import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil'
 
 import { formatDistance } from '../../i18n/dates'
 import { isDevEnv } from '../../lib/env'
+import { isEventDeletable } from '../../lib/event'
 import { Path } from '../../routeConfig'
 import AutocompleteSingle from '../components/AutocompleteSingle'
 import StyledDataGrid from '../components/StyledDataGrid'
@@ -148,7 +149,7 @@ export default function EventListPage() {
         )}
         <AutoButton
           startIcon={<DeleteOutline />}
-          disabled={!selectedEventID}
+          disabled={!selectedEventID || !isEventDeletable(selectedEvent)}
           onClick={deleteAction}
           text={t('delete')}
         />


### PR DESCRIPTION
This pull request introduces functionality to determine if an event is deletable based on its state and integrates this logic into the backend and frontend. The changes include adding a utility function, updating the event deletion logic in the backend, and ensuring the frontend respects these rules.

### Backend Changes:
* Added `isEventDeletable` utility function in `src/lib/event.ts` to determine if an event can be deleted based on its state. It returns `true` for states like 'draft', 'tentative', and 'cancelled', and `false` for others.
* Updated `putEventLambda` in `src/lambda/PutEventFunction/handler.ts` to prevent deletion of non-deletable events by checking `isEventDeletable`. A `403 Forbidden` response is returned if an event is not deletable.

### Backend Tests:
* Added unit tests for `isEventDeletable` in `src/lib/event.test.ts` to verify behavior for various event states.
* Extended `putEventLambda` tests in `src/lambda/PutEventFunction/putEventLambda.test.ts` to cover scenarios where event deletion is allowed or forbidden based on the state.

### Frontend Changes:
* Updated `EventListPage` in `src/pages/admin/EventListPage.tsx` to disable the delete button for events that are not deletable, using the `isEventDeletable` utility.