### PR TITLE
fix: disable rfid when dog is not found (and not in manual mode) (KOE-1050)

### DIFF
--- a/src/lib/dog.test.ts
+++ b/src/lib/dog.test.ts
@@ -1,0 +1,82 @@
+import { subMinutes } from 'date-fns'
+
+import { createDogUpdateFromFormValues, shouldAllowRefresh } from './dog'
+
+describe('dog utility functions', () => {
+  describe('shouldAllowRefresh', () => {
+    it('should return false if dog has no regNo', () => {
+      expect(shouldAllowRefresh({})).toBe(false)
+      expect(shouldAllowRefresh({ name: 'Test Dog' })).toBe(false)
+    })
+
+    it('should return false if dog was refreshed less than 5 minutes ago', () => {
+      const refreshDate = subMinutes(new Date(), 3)
+      expect(shouldAllowRefresh({ regNo: 'TEST-123', refreshDate })).toBe(false)
+    })
+
+    it('should return true if dog has regNo and refreshDate older than 5 minutes', () => {
+      const refreshDate = subMinutes(new Date(), 10)
+      expect(shouldAllowRefresh({ regNo: 'TEST-123', refreshDate })).toBe(true)
+    })
+
+    it('should return false if dog has regNo but no refreshDate', () => {
+      expect(shouldAllowRefresh({ regNo: 'TEST-123' })).toBe(false)
+    })
+  })
+
+  describe('createDogUpdateFromFormValues', () => {
+    it('should create a dog update object from form values', () => {
+      const dob = new Date('2020-01-01')
+      const formValues = {
+        rfid: '123456789',
+        name: 'Test Dog',
+        titles: 'CH',
+        dob,
+        gender: 'M' as const,
+        breedCode: '110' as const,
+        sire: 'Sire Name',
+        dam: 'Dam Name',
+      }
+
+      const result = createDogUpdateFromFormValues(formValues)
+
+      expect(result).toEqual({
+        rfid: '123456789',
+        name: 'Test Dog',
+        titles: 'CH',
+        dob,
+        gender: 'M',
+        breedCode: '110',
+        sire: { name: 'Sire Name' },
+        dam: { name: 'Dam Name' },
+      })
+    })
+
+    it('should handle empty gender and breedCode values', () => {
+      const dob = new Date('2020-01-01')
+      const formValues = {
+        rfid: '123456789',
+        name: 'Test Dog',
+        titles: 'CH',
+        dob,
+        gender: '' as const,
+        breedCode: '' as const,
+        sire: 'Sire Name',
+        dam: 'Dam Name',
+      }
+
+      const result = createDogUpdateFromFormValues(formValues)
+
+      expect(result).toEqual({
+        rfid: '123456789',
+        name: 'Test Dog',
+        titles: 'CH',
+        dob,
+        gender: undefined,
+        breedCode: undefined,
+        sire: { name: 'Sire Name' },
+        dam: { name: 'Dam Name' },
+      })
+    })
+  })
+})

--- a/src/lib/dog.ts
+++ b/src/lib/dog.ts
@@ -1,0 +1,47 @@
+import type { BreedCode, DeepPartial, Dog, DogGender } from '../types'
+
+import { differenceInMinutes } from 'date-fns'
+
+/**
+ * Determines if a dog's data should be allowed to be refreshed
+ * @param dog The dog data
+ * @returns True if refresh should be allowed, false otherwise
+ */
+export function shouldAllowRefresh(dog?: DeepPartial<Dog>): boolean {
+  if (!dog?.regNo) {
+    return false
+  }
+  if (dog.refreshDate && differenceInMinutes(new Date(), dog.refreshDate) <= 5) {
+    return false
+  }
+  return !!dog.refreshDate
+}
+
+/**
+ * Creates a dog update object from form values
+ * @param values Form values
+ * @returns Dog update object
+ */
+export function createDogUpdateFromFormValues(values: {
+  rfid: string
+  name: string
+  titles: string
+  dob: Date | undefined
+  gender: DogGender | ''
+  breedCode: BreedCode | ''
+  sire: string
+  dam: string
+}): DeepPartial<Dog> {
+  const { rfid, name, titles, dob, gender, breedCode, sire, dam } = values
+
+  return {
+    rfid,
+    name,
+    titles,
+    dob,
+    gender: gender || undefined,
+    breedCode: breedCode || undefined,
+    sire: { name: sire },
+    dam: { name: dam },
+  }
+}

--- a/src/pages/__snapshots__/RegistrationCreatePage.test.tsx.snap
+++ b/src/pages/__snapshots__/RegistrationCreatePage.test.tsx.snap
@@ -936,7 +936,7 @@ exports[`RegistrationCreatePage should render with event/eventType/id path 1`] =
                       </div>
                     </div>
                     <div
-                      class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-lg-6 MuiGrid2-spacing-xs-1 css-1oeyevi-MuiGrid2-root"
+                      class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-lg-6 MuiGrid2-spacing-xs-1 css-1vpvizr-MuiGrid2-root"
                     >
                       <div
                         class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-spacing-xs-1 css-jhnp0g-MuiGrid2-root"
@@ -3705,7 +3705,7 @@ exports[`RegistrationCreatePage should select the date on event/eventType/id/cla
                       </div>
                     </div>
                     <div
-                      class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-lg-6 MuiGrid2-spacing-xs-1 css-1oeyevi-MuiGrid2-root"
+                      class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-lg-6 MuiGrid2-spacing-xs-1 css-1vpvizr-MuiGrid2-root"
                     >
                       <div
                         class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-spacing-xs-1 css-jhnp0g-MuiGrid2-root"

--- a/src/pages/__snapshots__/RegistrationEditPage.test.tsx.snap
+++ b/src/pages/__snapshots__/RegistrationEditPage.test.tsx.snap
@@ -784,7 +784,7 @@ exports[`RegistrationEditPage should render 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-lg-6 MuiGrid2-spacing-xs-1 css-1oeyevi-MuiGrid2-root"
+                      class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-lg-6 MuiGrid2-spacing-xs-1 css-1vpvizr-MuiGrid2-root"
                     >
                       <div
                         class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-spacing-xs-1 css-jhnp0g-MuiGrid2-root"

--- a/src/pages/admin/eventViewPage/__snapshots__/RegistrationEditDialog.test.tsx.snap
+++ b/src/pages/admin/eventViewPage/__snapshots__/RegistrationEditDialog.test.tsx.snap
@@ -679,7 +679,7 @@ exports[`RegistrationEditDialog renders when registration is cancelled 1`] = `
                               </div>
                             </div>
                             <div
-                              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-lg-6 MuiGrid2-spacing-xs-1 css-1oeyevi-MuiGrid2-root"
+                              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-lg-6 MuiGrid2-spacing-xs-1 css-1vpvizr-MuiGrid2-root"
                             >
                               <div
                                 class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-spacing-xs-1 css-jhnp0g-MuiGrid2-root"
@@ -3439,7 +3439,7 @@ exports[`RegistrationEditDialog renders with minimal parameters 1`] = `
                               </div>
                             </div>
                             <div
-                              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-lg-6 MuiGrid2-spacing-xs-1 css-1oeyevi-MuiGrid2-root"
+                              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-lg-6 MuiGrid2-spacing-xs-1 css-1vpvizr-MuiGrid2-root"
                             >
                               <div
                                 class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-spacing-xs-1 css-jhnp0g-MuiGrid2-root"

--- a/src/pages/components/__snapshots__/RegistrationForm.test.tsx.snap
+++ b/src/pages/components/__snapshots__/RegistrationForm.test.tsx.snap
@@ -671,7 +671,7 @@ exports[`RegistrationForm renders 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-lg-6 MuiGrid2-spacing-xs-1 css-1oeyevi-MuiGrid2-root"
+                      class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-lg-6 MuiGrid2-spacing-xs-1 css-1vpvizr-MuiGrid2-root"
                     >
                       <div
                         class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-spacing-xs-1 css-jhnp0g-MuiGrid2-root"
@@ -3163,7 +3163,7 @@ exports[`RegistrationForm renders with invalid dog information 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-lg-6 MuiGrid2-spacing-xs-1 css-1oeyevi-MuiGrid2-root"
+                      class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-lg-6 MuiGrid2-spacing-xs-1 css-1vpvizr-MuiGrid2-root"
                     >
                       <div
                         class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-spacing-xs-1 css-jhnp0g-MuiGrid2-root"

--- a/src/pages/components/registrationForm/DogInfo.tsx
+++ b/src/pages/components/registrationForm/DogInfo.tsx
@@ -1,41 +1,23 @@
 import type { SyntheticEvent } from 'react'
-import type { BreedCode, DeepPartial, Dog, DogGender, Registration } from '../../../types'
+import type { BreedCode, DeepPartial, DogGender, Registration } from '../../../types'
 import type { DogCachedInfo } from '../../recoil/dog'
 
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Autocomplete from '@mui/material/Autocomplete'
-import Button from '@mui/material/Button'
-import CircularProgress from '@mui/material/CircularProgress'
-import FormControl from '@mui/material/FormControl'
-import FormHelperText from '@mui/material/FormHelperText'
 import Grid2 from '@mui/material/Grid2'
-import TextField from '@mui/material/TextField'
-import { Box } from '@mui/system'
-import { DatePicker } from '@mui/x-date-pickers'
-import { differenceInMinutes, subMonths, subYears } from 'date-fns'
 import { useRecoilValue } from 'recoil'
 
 import { emptyDog } from '../../../lib/data'
+import { createDogUpdateFromFormValues, shouldAllowRefresh } from '../../../lib/dog'
 import { hasChanges } from '../../../lib/utils'
 import { validateRegNo } from '../../../lib/validation'
 import { useDogActions } from '../../recoil/dog'
 import { cachedDogRegNumbersSelector } from '../../recoil/dog/selectors'
-import AutocompleteSingle from '../AutocompleteSingle'
 import CollapsibleSection from '../CollapsibleSection'
 
-import { TitlesAndName } from './dogInfo/TitlesAndName'
+import { DogDetails } from './dogInfo/DogDetails'
+import { DogSearch } from './dogInfo/DogSearch'
 import { useLocalStateGroup } from './hooks/useLocalStateGroup'
-
-function shouldAllowRefresh(dog?: DeepPartial<Dog>) {
-  if (!dog?.regNo) {
-    return false
-  }
-  if (dog.refreshDate && differenceInMinutes(new Date(), dog.refreshDate) <= 5) {
-    return false
-  }
-  return !!dog.refreshDate
-}
 
 interface Props {
   readonly reg: DeepPartial<Registration>
@@ -69,8 +51,6 @@ export const DogInfo = ({
   orgId,
 }: Props) => {
   const { t } = useTranslation()
-  const { t: breed } = useTranslation('breed')
-  // Basic state for dog registration
   const [state, setState] = useState<State>({
     regNo: reg?.dog?.regNo ?? '',
     mode: reg?.dog?.regNo ? 'update' : 'fetch',
@@ -99,22 +79,8 @@ export const DogInfo = ({
       dam: reg?.dog?.dam?.name ?? '',
     },
     (values) => {
-      // Handle all field updates as a group
-      const { rfid, name, titles, dob, gender, breedCode, sire, dam } = values
-
-      // Create a single update object with all changed fields
-      const dogUpdate: DeepPartial<Dog> = {
-        rfid,
-        name,
-        titles,
-        dob,
-        gender: gender || undefined,
-        breedCode: breedCode || undefined,
-        sire: { name: sire },
-        dam: { name: dam },
-      }
-
-      // Send all updates at once
+      // Create a dog update object and send it
+      const dogUpdate = createDogUpdateFromFormValues(values)
       handleChange({ dog: dogUpdate })
     }
   )
@@ -267,127 +233,34 @@ export const DogInfo = ({
     >
       <Grid2 container spacing={1} alignItems="flex-start">
         <Grid2 size={{ xs: 12, sm: 7, md: 6, lg: 3 }}>
-          <FormControl fullWidth>
-            <Box sx={{ display: 'flex', alignItems: 'center' }}>
-              <Autocomplete
-                id="txtReknro"
-                disabled={disabled || !disabledByMode}
-                freeSolo
-                renderInput={(props) => <TextField {...props} error={!validRegNo} label={t('dog.regNo')} />}
-                value={state.regNo}
-                inputValue={state.regNo}
-                onChange={handleRegNoSelect}
-                onInputChange={handleRegNoChange}
-                options={cachedRegNos ?? []}
-                sx={{ display: 'flex', flexGrow: 1, mr: 1 }}
-              />
-              <Button
-                disabled={disabled || !validRegNo || (state.mode === 'update' && !allowRefresh)}
-                variant="contained"
-                onClick={buttonClick}
-              >
-                {t(`registration.cta.${state.mode}`)}
-              </Button>
-              <CircularProgress size={28} sx={{ ml: 1, display: loading ? undefined : 'none' }} />
-            </Box>
-            <FormHelperText error={['notfound', 'error'].includes(state.mode)}>
-              {t(`registration.cta.helper.${state.mode}`, { date: reg?.dog?.refreshDate })}
-            </FormHelperText>
-          </FormControl>
-        </Grid2>
-        <Grid2 size={{ xs: 12, sm: 5, md: 6, lg: 3 }}>
-          <TextField
-            className={rfidDisabled && reg?.dog?.rfid ? 'fact' : ''}
-            disabled={disabled || rfidDisabled}
-            fullWidth
-            label={t('dog.rfid')}
-            value={formValues.rfid ?? ''}
-            error={!rfidDisabled && !formValues.rfid}
-            onChange={(e) => updateField('rfid', e.target.value)}
+          <DogSearch
+            regNo={state.regNo}
+            disabled={disabled}
+            disabledByMode={disabledByMode}
+            validRegNo={validRegNo}
+            allowRefresh={allowRefresh}
+            mode={state.mode}
+            loading={loading}
+            cachedRegNos={cachedRegNos}
+            refreshDate={reg?.dog?.refreshDate}
+            onRegNoChange={handleRegNoChange}
+            onRegNoSelect={handleRegNoSelect}
+            onButtonClick={buttonClick}
           />
         </Grid2>
-        <Grid2 container spacing={1} size={{ xs: 12, lg: 6 }}>
-          <TitlesAndName
-            className={disabledByMode && reg?.dog?.breedCode ? 'fact' : ''}
-            disabledTitles={disabled || (disabledByMode && state.mode !== 'update')}
-            disabledName={disabledByMode}
-            id="dog"
-            name={formValues.name}
-            nameLabel={t('dog.name')}
-            onChange={(props) => {
-              if (props.name !== undefined) updateField('name', props.name)
-              if (props.titles !== undefined) updateField('titles', props.titles)
-            }}
-            titles={formValues.titles}
-            titlesLabel={t('dog.titles')}
-          />
-        </Grid2>
-        <Grid2 size={{ xs: 6, sm: 3, lg: 3 }}>
-          <FormControl className={disabledByMode && reg?.dog?.dob ? 'fact' : ''} fullWidth>
-            <DatePicker
-              referenceDate={subYears(new Date(), 2)}
-              disabled={disabledByMode}
-              format={t('dateFormatString.long')}
-              label={t('dog.dob')}
-              maxDate={subMonths(eventDate, minDogAgeMonths)}
-              minDate={subYears(new Date(), 15)}
-              onChange={(value: any) => updateField('dob', value || undefined)}
-              openTo={'year'}
-              value={formValues.dob ?? null}
-              views={['year', 'month', 'day']}
-            />
-          </FormControl>
-        </Grid2>
-        <Grid2 size={{ xs: 6, sm: 3, lg: 3 }}>
-          <AutocompleteSingle<DogGender | '', true>
-            className={disabledByMode && reg?.dog?.gender ? 'fact' : ''}
-            disableClearable
-            disabled={disabledByMode}
-            error={!disabledByMode && !reg?.dog?.gender}
-            getOptionLabel={(o) => (o ? t(`dog.genderChoises.${o}`) : '')}
-            isOptionEqualToValue={(o, v) => o === v}
-            label={t('dog.gender')}
-            onChange={(value) => updateField('gender', value || '')}
-            options={['F', 'M'] as DogGender[]}
-            value={formValues.gender}
-          />
-        </Grid2>
-        <Grid2 size={{ xs: 12, sm: 6 }}>
-          <AutocompleteSingle<BreedCode | '', true>
-            className={disabledByMode && reg?.dog?.breedCode ? 'fact' : ''}
-            disableClearable
-            disabled={disabledByMode}
-            error={!disabledByMode && !reg?.dog?.breedCode}
-            getOptionLabel={(o) => (o ? breed(o) : '')}
-            isOptionEqualToValue={(o, v) => o === v}
-            label={t('dog.breed')}
-            onChange={(value) => updateField('breedCode', value || '')}
-            options={['122', '111', '121', '312', '110', '263']}
-            value={formValues.breedCode}
-          />
-        </Grid2>
-        <Grid2 size={{ xs: 12, lg: 6 }}>
-          <TextField
-            disabled={sireDamDisabled}
-            fullWidth
-            id={'sire'}
-            label={t('dog.sire.name')}
-            onChange={(e) => updateField('sire', e.target.value)}
-            error={!sireDamDisabled && !formValues.sire}
-            value={formValues.sire}
-          />
-        </Grid2>
-        <Grid2 size={{ xs: 12, lg: 6 }}>
-          <TextField
-            disabled={sireDamDisabled}
-            fullWidth
-            id={'dam'}
-            label={t('dog.dam.name')}
-            onChange={(e) => updateField('dam', e.target.value)}
-            error={!sireDamDisabled && !formValues.dam}
-            value={formValues.dam}
-          />
-        </Grid2>
+
+        <DogDetails
+          formValues={formValues}
+          updateField={updateField}
+          disabledByMode={disabledByMode}
+          rfidDisabled={rfidDisabled}
+          sireDamDisabled={sireDamDisabled}
+          disabled={disabled}
+          mode={state.mode}
+          reg={reg}
+          eventDate={eventDate}
+          minDogAgeMonths={minDogAgeMonths}
+        />
       </Grid2>
     </CollapsibleSection>
   )

--- a/src/pages/components/registrationForm/DogInfo.tsx
+++ b/src/pages/components/registrationForm/DogInfo.tsx
@@ -122,7 +122,7 @@ export const DogInfo = ({
   // Derived state
   const disabledByMode = disabled || state.mode !== 'manual'
   const sireDamDisabled = disabledByMode && (disabled || state.mode !== 'update')
-  const rfidDisabled = disabledByMode && !state.rfid
+  const rfidDisabled = disabledByMode && (!state.rfid || state.mode === 'notfound')
   const validRegNo = validateRegNo(state.regNo)
   const [loading, setLoading] = useState(false)
   const [delayed, setDelayed] = useState(false)

--- a/src/pages/components/registrationForm/__snapshots__/DogInfo.test.tsx.snap
+++ b/src/pages/components/registrationForm/__snapshots__/DogInfo.test.tsx.snap
@@ -205,7 +205,7 @@ exports[`DogInfo should render 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-lg-6 MuiGrid2-spacing-xs-1 css-1oeyevi-MuiGrid2-root"
+                  class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-lg-6 MuiGrid2-spacing-xs-1 css-1vpvizr-MuiGrid2-root"
                 >
                   <div
                     class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-spacing-xs-1 css-jhnp0g-MuiGrid2-root"

--- a/src/pages/components/registrationForm/dogInfo/DogDetails.tsx
+++ b/src/pages/components/registrationForm/dogInfo/DogDetails.tsx
@@ -1,0 +1,151 @@
+import type { BreedCode, DeepPartial, DogGender, Registration } from '../../../../types'
+import type { DogMode } from './DogSearch'
+
+import { useTranslation } from 'react-i18next'
+import FormControl from '@mui/material/FormControl'
+import Grid2 from '@mui/material/Grid2'
+import TextField from '@mui/material/TextField'
+import { DatePicker } from '@mui/x-date-pickers'
+import { subMonths, subYears } from 'date-fns'
+
+import AutocompleteSingle from '../../AutocompleteSingle'
+
+import { TitlesAndName } from './TitlesAndName'
+
+export interface DogFormValues {
+  rfid: string
+  name: string
+  titles: string
+  dob: Date | undefined
+  gender: DogGender | ''
+  breedCode: BreedCode | ''
+  sire: string
+  dam: string
+}
+
+interface DogDetailsProps {
+  formValues: DogFormValues
+  updateField: (field: keyof DogFormValues, value: any) => void
+  disabledByMode: boolean
+  rfidDisabled: boolean
+  sireDamDisabled: boolean
+  disabled?: boolean
+  mode: DogMode
+  reg: DeepPartial<Registration>
+  eventDate: Date
+  minDogAgeMonths: number
+}
+
+export const DogDetails = ({
+  formValues,
+  updateField,
+  disabledByMode,
+  rfidDisabled,
+  sireDamDisabled,
+  disabled,
+  mode,
+  reg,
+  eventDate,
+  minDogAgeMonths,
+}: Readonly<DogDetailsProps>) => {
+  const { t } = useTranslation()
+  const { t: breed } = useTranslation('breed')
+
+  return (
+    <>
+      <Grid2 size={{ xs: 12, sm: 5, md: 6, lg: 3 }}>
+        <TextField
+          className={rfidDisabled && reg?.dog?.rfid ? 'fact' : ''}
+          disabled={disabled || rfidDisabled}
+          fullWidth
+          label={t('dog.rfid')}
+          value={formValues.rfid ?? ''}
+          error={!rfidDisabled && !formValues.rfid}
+          onChange={(e) => updateField('rfid', e.target.value)}
+        />
+      </Grid2>
+      <Grid2 container spacing={1} size={{ xs: 12, lg: 6 }}>
+        <TitlesAndName
+          className={disabledByMode && reg?.dog?.breedCode ? 'fact' : ''}
+          disabledTitles={disabled || (disabledByMode && mode !== 'update')}
+          disabledName={disabledByMode}
+          id="dog"
+          name={formValues.name}
+          nameLabel={t('dog.name')}
+          onChange={(props) => {
+            if (props.name !== undefined) updateField('name', props.name)
+            if (props.titles !== undefined) updateField('titles', props.titles)
+          }}
+          titles={formValues.titles}
+          titlesLabel={t('dog.titles')}
+        />
+      </Grid2>
+      <Grid2 size={{ xs: 6, sm: 3, lg: 3 }}>
+        <FormControl className={disabledByMode && reg?.dog?.dob ? 'fact' : ''} fullWidth>
+          <DatePicker
+            referenceDate={subYears(new Date(), 2)}
+            disabled={disabledByMode}
+            format={t('dateFormatString.long')}
+            label={t('dog.dob')}
+            maxDate={subMonths(eventDate, minDogAgeMonths)}
+            minDate={subYears(new Date(), 15)}
+            onChange={(value: any) => updateField('dob', value || undefined)}
+            openTo={'year'}
+            value={formValues.dob ?? null}
+            views={['year', 'month', 'day']}
+          />
+        </FormControl>
+      </Grid2>
+      <Grid2 size={{ xs: 6, sm: 3, lg: 3 }}>
+        <AutocompleteSingle<DogGender | '', true>
+          className={disabledByMode && reg?.dog?.gender ? 'fact' : ''}
+          disableClearable
+          disabled={disabledByMode}
+          error={!disabledByMode && !reg?.dog?.gender}
+          getOptionLabel={(o) => (o ? t(`dog.genderChoises.${o}`) : '')}
+          isOptionEqualToValue={(o, v) => o === v}
+          label={t('dog.gender')}
+          onChange={(value) => updateField('gender', value || '')}
+          options={['F', 'M'] as DogGender[]}
+          value={formValues.gender}
+        />
+      </Grid2>
+      <Grid2 size={{ xs: 12, sm: 6 }}>
+        <AutocompleteSingle<BreedCode | '', true>
+          className={disabledByMode && reg?.dog?.breedCode ? 'fact' : ''}
+          disableClearable
+          disabled={disabledByMode}
+          error={!disabledByMode && !reg?.dog?.breedCode}
+          getOptionLabel={(o) => (o ? breed(o) : '')}
+          isOptionEqualToValue={(o, v) => o === v}
+          label={t('dog.breed')}
+          onChange={(value) => updateField('breedCode', value || '')}
+          options={['122', '111', '121', '312', '110', '263']}
+          value={formValues.breedCode}
+        />
+      </Grid2>
+      <Grid2 size={{ xs: 12, lg: 6 }}>
+        <TextField
+          disabled={sireDamDisabled}
+          fullWidth
+          id={'sire'}
+          label={t('dog.sire.name')}
+          onChange={(e) => updateField('sire', e.target.value)}
+          error={!sireDamDisabled && !formValues.sire}
+          value={formValues.sire}
+        />
+      </Grid2>
+      <Grid2 size={{ xs: 12, lg: 6 }}>
+        <TextField
+          disabled={sireDamDisabled}
+          fullWidth
+          id={'dam'}
+          label={t('dog.dam.name')}
+          onChange={(e) => updateField('dam', e.target.value)}
+          error={!sireDamDisabled && !formValues.dam}
+          value={formValues.dam}
+        />
+      </Grid2>
+    </>
+  )
+}

--- a/src/pages/components/registrationForm/dogInfo/DogSearch.tsx
+++ b/src/pages/components/registrationForm/dogInfo/DogSearch.tsx
@@ -1,0 +1,74 @@
+import type { SyntheticEvent } from 'react'
+
+import { useTranslation } from 'react-i18next'
+import Autocomplete from '@mui/material/Autocomplete'
+import Button from '@mui/material/Button'
+import CircularProgress from '@mui/material/CircularProgress'
+import FormControl from '@mui/material/FormControl'
+import FormHelperText from '@mui/material/FormHelperText'
+import TextField from '@mui/material/TextField'
+import { Box } from '@mui/system'
+
+export type DogMode = 'fetch' | 'manual' | 'update' | 'notfound' | 'autofetch' | 'error'
+
+interface DogSearchProps {
+  regNo: string
+  disabled?: boolean
+  disabledByMode: boolean
+  validRegNo: boolean
+  allowRefresh: boolean
+  mode: DogMode
+  loading: boolean
+  cachedRegNos: string[] | null
+  refreshDate?: Date
+  onRegNoChange: (event: SyntheticEvent<Element, Event>, value: string | null) => void
+  onRegNoSelect: (event: SyntheticEvent<Element, Event>, value: string | null) => void
+  onButtonClick: () => void
+}
+
+export const DogSearch = ({
+  regNo,
+  disabled,
+  disabledByMode,
+  validRegNo,
+  allowRefresh,
+  mode,
+  loading,
+  cachedRegNos,
+  refreshDate,
+  onRegNoChange,
+  onRegNoSelect,
+  onButtonClick,
+}: DogSearchProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <FormControl fullWidth>
+      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        <Autocomplete
+          id="txtReknro"
+          disabled={disabled || !disabledByMode}
+          freeSolo
+          renderInput={(props) => <TextField {...props} error={!validRegNo} label={t('dog.regNo')} />}
+          value={regNo}
+          inputValue={regNo}
+          onChange={onRegNoSelect}
+          onInputChange={onRegNoChange}
+          options={cachedRegNos ?? []}
+          sx={{ display: 'flex', flexGrow: 1, mr: 1 }}
+        />
+        <Button
+          disabled={disabled || !validRegNo || (mode === 'update' && !allowRefresh)}
+          variant="contained"
+          onClick={onButtonClick}
+        >
+          {t(`registration.cta.${mode}`)}
+        </Button>
+        <CircularProgress size={28} sx={{ ml: 1, display: loading ? undefined : 'none' }} />
+      </Box>
+      <FormHelperText error={['notfound', 'error'].includes(mode)}>
+        {t(`registration.cta.helper.${mode}`, { date: refreshDate })}
+      </FormHelperText>
+    </FormControl>
+  )
+}


### PR DESCRIPTION
This pull request makes improvements to the `DogInfo` component and its associated tests to handle RFID input more robustly based on the state of the dog fetched from the API. Key changes include updates to the component's logic and the addition of new test cases to verify these behaviors.

### Changes to `DogInfo` Component Logic:

* Updated the `rfidDisabled` calculation in `DogInfo.tsx` to disable the RFID field when the dog is not found in the API (`state.mode === 'notfound`). This ensures the field is appropriately disabled in error states.

### Changes to `DogInfo` Tests:

* Replaced `beforeAll` with `beforeEach` for timer setup and added `localStorage.clear()` in `afterEach` to improve test reliability and ensure a clean environment for each test.
* Added a test case to verify that RFID input is allowed for dogs fetched from the API without an RFID. This test ensures the RFID field is enabled and updates correctly when a new RFID is entered.
* Added a test case to verify that the RFID field is disabled when the dog is not found in the API. This ensures the field reflects the "notfound" state accurately.