### PR TITLE
fix: never downgrade event state (KOE-1053)

### DIFF
--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -105,6 +105,7 @@ export type JsonEventClass = {
 export type EventClass = Replace<JsonEventClass, 'date', Date>
 
 export type EventClassState = 'picked' | 'invited' | 'started' | 'ended' | 'completed'
+export type ConfirmedEventStates = 'confirmed' | EventClassState
 export type EventState = 'draft' | 'tentative' | 'cancelled' | 'confirmed' | EventClassState
 
 export type Headquarters = {


### PR DESCRIPTION
This pull request introduces enhancements to event state management and testing in the `src/lambda/lib/event.ts` module. Key changes include the addition of utility functions for upgrading states, modifications to the `markParticipants` function for state progression, and extensive updates to unit tests to cover new functionality.

### Enhancements to event state management:

* Added `upgradeClassState` and `upgradeEventState` utility functions to handle state progression based on predefined precedence rules. (`src/lambda/lib/event.ts`, [src/lambda/lib/event.tsR83-R104](diffhunk://#diff-5e3c7b9735851fb44c0b02f9ededb8a4246b37e5c77422b943bfc7e41da4d86dR83-R104))
* Updated the `markParticipants` function to use `upgradeClassState` and `upgradeEventState` for class and event state updates, ensuring proper handling of state transitions. (`src/lambda/lib/event.ts`, [src/lambda/lib/event.tsL88-R121](diffhunk://#diff-5e3c7b9735851fb44c0b02f9ededb8a4246b37e5c77422b943bfc7e41da4d86dL88-R121))

### Updates to unit tests:

* Expanded test coverage in `src/lambda/lib/event.test.ts` to validate state progression logic for both classes and events, including edge cases such as downgrades and undefined states. (`src/lambda/lib/event.test.ts`, F33b7ed0L176R284, [src/lambda/lib/event.test.tsR846-R900](diffhunk://#diff-53f83a86f5f1fc68aa6cd78f20f624e3e02497d237f2f7333e6bb4156368ec5dR846-R900))
* Added tests for scenarios where no `eventClass` parameter is provided, ensuring all classes and event states are updated correctly. (`src/lambda/lib/event.test.ts`, F33b7ed0L176R284)
* Introduced tests for handling the `updatedRegistrations` parameter, verifying correct counts and database interactions. (`src/lambda/lib/event.test.ts`, [src/lambda/lib/event.test.tsR338-R456](diffhunk://#diff-53f83a86f5f1fc68aa6cd78f20f624e3e02497d237f2f7333e6bb4156368ec5dR338-R456))

### Type definitions:

* Added `ConfirmedEventStates` type to represent event states that include `confirmed` alongside class states, improving type safety. (`src/types/Event.ts`, [src/types/Event.tsR108](diffhunk://#diff-5786b1d6debebc8980dc81b0cd62158df7c6d1e2a6f3582d9fb10a4616c8ada2R108))